### PR TITLE
Exception Occurred During Liquibase Update

### DIFF
--- a/lqbasetest-mssql/Readme.md
+++ b/lqbasetest-mssql/Readme.md
@@ -28,7 +28,7 @@
 	 - Server Instance is **localhost\SQLEXPRESS2019**
 	 - Database Name is **test**
 - We've added following (as default) configuration in liquibase.properties file. If we don't provide these parameters with command, default value will be used from properties file.
-	- url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;database=test
+	- url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;encrypt=false;database=test
 	- username=sa
 	- password=P@ssword1
 	- liquibase.hub.mode=off

--- a/lqbasetest-mssql/example1/liquibase.properties
+++ b/lqbasetest-mssql/example1/liquibase.properties
@@ -1,5 +1,5 @@
 
-url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;database=test
+url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;encrypt=false;database=test
 username=sa
 password=P@ssword1
 liquibase.hub.mode=off

--- a/lqbasetest-mssql/example2/liquibase.properties
+++ b/lqbasetest-mssql/example2/liquibase.properties
@@ -1,5 +1,5 @@
 
-url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;database=test
+url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;encrypt=false;database=test
 username=sa
 password=P@ssword1
 liquibase.hub.mode=off

--- a/lqbasetest-mssql/example3/liquibase.properties
+++ b/lqbasetest-mssql/example3/liquibase.properties
@@ -1,5 +1,5 @@
 
-url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;database=test
+url=jdbc:sqlserver://localhost\\SQLEXPRESS2019:1433;encrypt=false;database=test
 username=sa
 password=P@ssword1
 liquibase.hub.mode=off


### PR DESCRIPTION
Unexpected error running Liquibase: Connection could not be created to jdbc:sqlserver://localhost:1433;integratedSecurity=false;database=Liquibase_Test with driver com.microsoft.sqlserver.jdbc.SQLServerDriver.  "encrypt" property is set to "true" and "trustServerCertificate" property is set to "false" but the driver could not establish a secure connection to SQL Server by using Secure Sockets Layer (SSL) encryption: Error: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target. 